### PR TITLE
ci(appveyor): disable node 9

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,6 @@
 environment:
   matrix:
   - nodejs_version: "10"
-  - nodejs_version: "9"
   - nodejs_version: "8"
 
 install:


### PR DESCRIPTION
appveyor is very slow and builds sequentially, so we make the build times a bit more bearable by removing a third of the work.