### PR TITLE
build(tslint): blacklist old (non-scoped) babel packages

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -11,6 +11,7 @@
     "no-function-constructor-with-string-args": false,
     "function-name": false,
     "import-name": false,
-    "ordered-imports": [true, { "grouped-imports": true }]
+    "ordered-imports": [true, { "grouped-imports": true }],
+    "import-blacklist": [true, "babel-core", "babel-traverse", "babel-types"]
   }
 }


### PR DESCRIPTION
Because of the @types packages,
which still refer to the Babel 6,
one might easily make the mistake
to import an old Babel package.
These are now blacklisted via the
import-blacklist tslint rule.