### PR TITLE
test: jest --watch instead of --watchAll

### DIFF
--- a/integration-tests/ava.test.ts
+++ b/integration-tests/ava.test.ts
@@ -1,5 +1,8 @@
 import { modulePath, resolvePath, runWithTypescriptJit } from './utils';
 
+// mark implicit dependencies for jest
+() => require('./ava/ava.js') && require('./ava/package.json');
+
 const avaCli = resolvePath(modulePath('ava'), 'cli.js');
 const cwd = resolvePath('ava');
 

--- a/integration-tests/ava/.babelrc
+++ b/integration-tests/ava/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": [["@babel/preset-env", { "targets": { "node": 6 } }]]
-}

--- a/integration-tests/ava/package.json
+++ b/integration-tests/ava/package.json
@@ -7,5 +7,8 @@
         "plugins": ["../../packages/babel-plugin-spock/src/index.ts"]
       }
     }
+  },
+  "babel": {
+    "presets": [["@babel/preset-env", { "targets": { "node": 6 } }]]
   }
 }

--- a/integration-tests/codemod.test.ts
+++ b/integration-tests/codemod.test.ts
@@ -8,6 +8,12 @@ import {
   runWithTypescriptJit,
 } from './utils';
 
+// mark implicit dependencies for jest
+() =>
+  require('./codemod/codemod.js') &&
+  require('./codemod/config.json') &&
+  require('./codemod/package.json');
+
 const babelCli = resolvePath(modulePath('@babel/cli'), 'bin', 'babel');
 const cwd = resolvePath('codemod');
 const babelConfig = resolvePath(cwd, 'config.json');

--- a/integration-tests/codemod/.babelrc
+++ b/integration-tests/codemod/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": [["@babel/preset-env", { "targets": { "node": 6 } }]]
-}

--- a/integration-tests/codemod/package.json
+++ b/integration-tests/codemod/package.json
@@ -1,0 +1,5 @@
+{
+  "babel": {
+    "presets": [["@babel/preset-env", { "targets": { "node": 6 } }]]
+  }
+}

--- a/integration-tests/jasmine.test.ts
+++ b/integration-tests/jasmine.test.ts
@@ -9,6 +9,9 @@ import {
   typescriptJitEnv,
 } from './utils';
 
+// mark implicit dependencies for jest
+() => require('./jasmine/jasmine.js') && require('./jasmine/package.json');
+
 const jasmineCli = resolvePath(modulePath('jasmine'), 'bin', 'jasmine');
 const cwd = resolvePath('jasmine');
 const jasmineConfig = resolvePath(cwd, 'jasmine.json');

--- a/integration-tests/jasmine/.babelrc
+++ b/integration-tests/jasmine/.babelrc
@@ -1,4 +1,0 @@
-{
-  "presets": [["@babel/preset-env", { "targets": { "node": 6 } }]],
-  "plugins": ["@spockjs/babel-plugin-spock"]
-}

--- a/integration-tests/jasmine/package.json
+++ b/integration-tests/jasmine/package.json
@@ -1,0 +1,6 @@
+{
+  "babel": {
+    "presets": [["@babel/preset-env", { "targets": { "node": 6 } }]],
+    "plugins": ["@spockjs/babel-plugin-spock"]
+  }
+}

--- a/integration-tests/jest.test.ts
+++ b/integration-tests/jest.test.ts
@@ -1,5 +1,8 @@
 import { modulePath, resolvePath, runWithTypescriptJit } from './utils';
 
+// mark implicit dependencies for jest
+() => require('./jest/jest.js') && require('./jest/package.json');
+
 const jestCli = resolvePath(modulePath('jest-cli'), 'bin', 'jest');
 const cwd = resolvePath('jest');
 

--- a/integration-tests/jest/.babelrc
+++ b/integration-tests/jest/.babelrc
@@ -1,4 +1,0 @@
-{
-  "presets": [["@babel/preset-env", { "targets": { "node": 6 } }]],
-  "plugins": ["@spockjs/babel-plugin-spock"]
-}

--- a/integration-tests/jest/jest.config.js
+++ b/integration-tests/jest/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  testEnvironment: 'node',
-  testRegex: 'jest.js',
-};

--- a/integration-tests/jest/package.json
+++ b/integration-tests/jest/package.json
@@ -1,0 +1,10 @@
+{
+  "babel": {
+    "presets": [["@babel/preset-env", { "targets": { "node": 6 } }]],
+    "plugins": ["@spockjs/babel-plugin-spock"]
+  },
+  "jest": {
+    "testEnvironment": "node",
+    "testRegex": "jest.js"
+  }
+}

--- a/integration-tests/mocha.test.ts
+++ b/integration-tests/mocha.test.ts
@@ -10,6 +10,9 @@ import {
   typescriptJitEnv,
 } from './utils';
 
+// mark implicit dependencies for jest
+() => require('./mocha/mocha.js') && require('./mocha/package.json');
+
 const mochaCli = resolvePath(modulePath('mocha'), 'bin', 'mocha');
 const cwd = resolvePath('mocha');
 

--- a/integration-tests/mocha/.babelrc
+++ b/integration-tests/mocha/.babelrc
@@ -1,4 +1,0 @@
-{
-  "presets": [["@babel/preset-env", { "targets": { "node": 6 } }]],
-  "plugins": ["@spockjs/babel-plugin-spock"]
-}

--- a/integration-tests/mocha/package.json
+++ b/integration-tests/mocha/package.json
@@ -1,0 +1,6 @@
+{
+  "babel": {
+    "presets": [["@babel/preset-env", { "targets": { "node": 6 } }]],
+    "plugins": ["@spockjs/babel-plugin-spock"]
+  }
+}

--- a/integration-tests/tape.test.ts
+++ b/integration-tests/tape.test.ts
@@ -11,6 +11,9 @@ import {
   typescriptJitEnv,
 } from './utils';
 
+// mark implicit dependencies for jest
+() => require('./tape/tape.js') && require('./tape/package.json');
+
 const tapeCli = resolvePath(modulePath('tape'), 'bin', 'tape');
 const cwd = resolvePath('tape');
 

--- a/integration-tests/tape/.babelrc
+++ b/integration-tests/tape/.babelrc
@@ -1,4 +1,0 @@
-{
-  "presets": [["@babel/preset-env", { "targets": { "node": 6 } }]],
-  "plugins": ["@spockjs/babel-plugin-spock"]
-}

--- a/integration-tests/tape/package.json
+++ b/integration-tests/tape/package.json
@@ -1,0 +1,6 @@
+{
+  "babel": {
+    "presets": [["@babel/preset-env", { "targets": { "node": 6 } }]],
+    "plugins": ["@spockjs/babel-plugin-spock"]
+  }
+}

--- a/integration-tests/utils.ts
+++ b/integration-tests/utils.ts
@@ -4,6 +4,9 @@ import { getInstalledPathSync } from 'get-installed-path';
 import which from 'npm-which';
 import * as path from 'path';
 
+// mark implicit dependency for Jest
+() => require('@spockjs/babel-plugin-spock');
+
 /*
   Integration tests execute the test runners with ts-node
   so that we can use the plugin's index.ts directly for

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "tslint --project .",
     "typecheck": "tsc",
     "test-once": "ts-node --transpileOnly --project tsconfig.json node_modules/jest-cli/bin/jest.js --coverage --no-cache",
-    "test-only": "yarn run test-once --watchAll",
+    "test-only": "yarn run test-once --watch",
     "test": "yarn run test-only --projects jest.config.js jest-tslint.config.js",
     "prebuild": "lerna exec --scope @spockjs/babel-plugin-spock --include-filtered-dependencies -- tsc --project tsconfig.d.json",
     "build": "lerna exec --scope @spockjs/babel-plugin-spock --include-filtered-dependencies -- babel src -d dist --extensions .ts --ignore .*\\/__tests__\\/.* --ignore .*\\/__mocks__\\/.*",


### PR DESCRIPTION
integration tests now declare implicit dependencies
to @spockjs/babel-plugin-spock and to test resources
via a "hidden" (never executed) `require`.

hidden files (`.babelrc`) as test resources are avoided
because Jest does not watch them.