### PR TITLE
feat: remove `expect`/`then` labels

### DIFF
--- a/integration-tests/__snapshots__/codemod.test.ts.snap
+++ b/integration-tests/__snapshots__/codemod.test.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`generates code that looks hand-written 1`] = `
 "import assert from \\"assert\\";
-
-expect: assert(1 === 2);
+assert(1 === 2);
 "
 `;

--- a/packages/babel-plugin-spock/src/__tests__/__snapshots__/assert-function-name.test.ts.snap
+++ b/packages/babel-plugin-spock/src/__tests__/__snapshots__/assert-function-name.test.ts.snap
@@ -5,22 +5,20 @@ exports[`does not rename non-conflicting bindings of the same name 1`] = `
 {
   let check;
 }
-
-expect: check(1 === 1);"
+check(1 === 1);"
 `;
 
 exports[`generates import with specified name when autoImport is set 1`] = `
 "import check from \\"power-assert\\";
-
-expect: check(1 === 1);"
+check(1 === 1);"
 `;
 
-exports[`generates specified assert function 1`] = `"expect: check(1 === 1);"`;
+exports[`generates specified assert function 1`] = `"check(1 === 1);"`;
 
 exports[`renames conflicting bindings when autoImporting 1`] = `
 "import check from \\"power-assert\\";
 
 let _check;
 
-expect: check(1 === 1);"
+check(1 === 1);"
 `;

--- a/packages/babel-plugin-spock/src/__tests__/__snapshots__/auto-import.test.ts.snap
+++ b/packages/babel-plugin-spock/src/__tests__/__snapshots__/auto-import.test.ts.snap
@@ -6,7 +6,7 @@ import fancyAssert from 'power-assert';
 {
   let fancyAssert;
 
-  expect: _assert(1 === 1);
+  _assert(1 === 1);
 }"
 `;
 
@@ -14,7 +14,7 @@ exports[`does not attempt to use an existing named import 1`] = `
 "import _assert from \\"power-assert\\";
 import { fancyAssert } from 'power-assert';
 
-expect: _assert(1 === 1);"
+_assert(1 === 1);"
 `;
 
 exports[`does not break preset-env module transform and generates code runnable in node 1`] = `"false == true"`;
@@ -22,12 +22,12 @@ exports[`does not break preset-env module transform and generates code runnable 
 exports[`does not clash with an existing "_assert" identifier in another scope after adding an import 1`] = `
 "import _assert2 from \\"power-assert\\";
 
-expect: _assert2(1 === 1);
+_assert2(1 === 1);
 
 {
   let _assert;
 
-  expect: _assert2(2 === 2);
+  _assert2(2 === 2);
 }"
 `;
 
@@ -35,41 +35,40 @@ exports[`does not clash with an existing "_assert" import 1`] = `
 "import _assert2 from \\"power-assert\\";
 import _assert from 'fancy-assert';
 
-expect: _assert2(1 === 1);"
+_assert2(1 === 1);"
 `;
 
 exports[`imports from a custom source 1`] = `
 "import _assert from \\"fancy-assert\\";
 
-expect: _assert(1 === 1);"
+_assert(1 === 1);"
 `;
 
 exports[`imports from power-assert by default 1`] = `
 "import _assert from \\"power-assert\\";
 
-expect: _assert(1 === 1);"
+_assert(1 === 1);"
 `;
 
 exports[`reuses the same import for multiple assertions 1`] = `
 "import _assert from \\"power-assert\\";
 
-expect: _assert(1 === 1);
+_assert(1 === 1);
 
-expect: _assert(2 === 2);"
+_assert(2 === 2);"
 `;
 
 exports[`reuses the same import for multiple assertions in nested scopes 1`] = `
 "import _assert from \\"power-assert\\";
 
 (() => {
-  expect: _assert(1 === 1);
+  _assert(1 === 1);
 
-  expect: _assert(2 === 2);
+  _assert(2 === 2);
 })();"
 `;
 
 exports[`uses an existing default import 1`] = `
 "import fancyAssert from 'power-assert';
-
-expect: fancyAssert(1 === 1);"
+fancyAssert(1 === 1);"
 `;

--- a/packages/babel-plugin-spock/src/__tests__/__snapshots__/simple-assertion.test.ts.snap
+++ b/packages/babel-plugin-spock/src/__tests__/__snapshots__/simple-assertion.test.ts.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`assertifies a "then"-labeled expression statement 1`] = `"then: assert(1 === 1);"`;
+exports[`assertifies a "then"-labeled expression statement 1`] = `"assert(1 === 1);"`;
 
 exports[`assertifies all expression statements in a labeled block statement 1`] = `
-"expect: {
+"{
   assert(1 === 1);
   assert(0.5 * 4 < 3);
   assert(abc.xyz() === 'result');
@@ -11,13 +11,13 @@ exports[`assertifies all expression statements in a labeled block statement 1`] 
 }"
 `;
 
-exports[`assertifies an "expect"-labeled expression statement 1`] = `"expect: assert(1 === 1);"`;
+exports[`assertifies an "expect"-labeled expression statement 1`] = `"assert(1 === 1);"`;
 
 exports[`assertifies inside an if / else statement 1`] = `
 "if (1 < 2) {
-  expect: assert(1 < 2);
+  assert(1 < 2);
 } else {
-  expect: assert(1 >= 2);
+  assert(1 >= 2);
 }"
 `;
 

--- a/packages/babel-plugin-spock/src/index.ts
+++ b/packages/babel-plugin-spock/src/index.ts
@@ -27,6 +27,8 @@ const plugin = (babel: { types: typeof BabelTypes }): PluginObj => {
             default:
               assertify(bodyPath);
           }
+
+          path.replaceWith(bodyPath);
         }
       },
     },


### PR DESCRIPTION
particularly useful for the codemod escape route,
leaving you just with plain assertions in your tests.
Closes #47