### PR TITLE
feat: validate babel-plugin-spock config

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,4 +2,5 @@ coverage/**/*
 **/dist/**/*
 
 CHANGELOG.md
-package.json
+/package.json
+/packages/*/package.json

--- a/functional-tests/babel-plugin-spock/__snapshots__/invalid-config.test.ts.snap
+++ b/functional-tests/babel-plugin-spock/__snapshots__/invalid-config.test.ts.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`throws if the config contains an invalid data type 1`] = `
+"Invalid plugin configuration:
+Invalid value 42 supplied to : Config/powerAssert: (boolean | undefined)/0: boolean
+Invalid value 42 supplied to : Config/powerAssert: (boolean | undefined)/1: undefined"
+`;
+
+exports[`throws if the config contains an unknown key 1`] = `
+"Invalid plugin configuration:
+Invalid value true supplied to : Config/asdf: never"
+`;

--- a/functional-tests/babel-plugin-spock/invalid-config.test.ts
+++ b/functional-tests/babel-plugin-spock/invalid-config.test.ts
@@ -1,0 +1,18 @@
+import { transform } from '@babel/core';
+import plugin from '@spockjs/babel-plugin-spock';
+
+test('throws if the config contains an unknown key', () => {
+  expect(() =>
+    transform(`expect: 1 === 1;`, {
+      plugins: [[plugin, { asdf: true }]],
+    }),
+  ).toThrowErrorMatchingSnapshot();
+});
+
+test('throws if the config contains an invalid data type', () => {
+  expect(() =>
+    transform(`expect: 1 === 1;`, {
+      plugins: [[plugin, { powerAssert: 42 }]],
+    }),
+  ).toThrowErrorMatchingSnapshot();
+});

--- a/integration-tests/ava/invalid-config/__snapshots__/ava-invalid-config.test.ts.snap
+++ b/integration-tests/ava/invalid-config/__snapshots__/ava-invalid-config.test.ts.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`reports a transform error 1`] = `
+"
+  Uncaught exception in ava.js
+  undefined
+  Error: Invalid plugin configuration:
+  Invalid value true supplied to : Config/asdf: never"
+`;

--- a/integration-tests/ava/invalid-config/ava-invalid-config.test.ts
+++ b/integration-tests/ava/invalid-config/ava-invalid-config.test.ts
@@ -1,0 +1,15 @@
+import { resolve } from 'path';
+
+import { runAva } from '../ava';
+
+// mark implicit dependencies for jest
+() => require('./workdir/ava.js') && require('./workdir/package.json');
+
+const cwd = resolve(__dirname, 'workdir');
+
+test('reports a transform error', () => {
+  const { status, stderr } = runAva(cwd);
+
+  expect: status === 1;
+  expect(stderr.replace(/\n\s+at.+config.+/s, '')).toMatchSnapshot();
+});

--- a/integration-tests/ava/invalid-config/workdir/ava.js
+++ b/integration-tests/ava/invalid-config/workdir/ava.js
@@ -1,0 +1,13 @@
+import test from 'ava';
+
+test('successful test', t => {
+  expect: 1 === 1;
+});
+
+test('failing test', t => {
+  let x;
+  const double = n => n * 2;
+
+  when: x = 3;
+  then: x === double(2);
+});

--- a/integration-tests/ava/invalid-config/workdir/package.json
+++ b/integration-tests/ava/invalid-config/workdir/package.json
@@ -1,0 +1,19 @@
+{
+  "ava": {
+    "files": ["ava.js"],
+    "failWithoutAssertions": false,
+    "babel": {
+      "testOptions": {
+        "plugins": [
+          [
+            "../../../../packages/babel-plugin-spock/src/index.ts",
+            { "asdf": true }
+          ]
+        ]
+      }
+    }
+  },
+  "babel": {
+    "presets": [["@babel/preset-env", { "targets": { "node": 6 } }]]
+  }
+}

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -18,5 +18,8 @@
   },
   "bugs": {
     "url": "https://github.com/spockjs/spockjs/issues"
+  },
+  "dependencies": {
+    "io-ts": "^1.1.2"
   }
 }

--- a/packages/config/src/hooks.ts
+++ b/packages/config/src/hooks.ts
@@ -10,5 +10,5 @@ export type AssertionPostProcessor = (
 ) => NodePath<BabelTypes.ExpressionStatement>;
 
 export interface Hooks {
-  assertionPostProcessors: AssertionPostProcessor[];
+  readonly assertionPostProcessors: ReadonlyArray<AssertionPostProcessor>;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3090,6 +3090,10 @@ form-data@~2.3.1:
     combined-stream "1.0.6"
     mime-types "^2.1.12"
 
+fp-ts@^1.0.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-1.5.0.tgz#f1f6498d44ecedd38465728012da549932aa4ef0"
+
 fragment-cache@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/fragment-cache/-/fragment-cache-0.2.1.tgz#4290fad27f13e89be7f33799c6bc5a0abfff0d19"
@@ -3620,6 +3624,12 @@ inversify@^4.10.0:
 invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
+
+io-ts@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/io-ts/-/io-ts-1.1.2.tgz#e6e4bbea51183e3bff38cacb435becdb637feffb"
+  dependencies:
+    fp-ts "^1.0.0"
 
 irregular-plurals@^1.0.0:
   version "1.4.0"


### PR DESCRIPTION
BREAKING CHANGE:
If you previously passed an invalid configuration object to the plugin,
but it still worked correctly, you will now get an error.

closes #46 