### PR TITLE
build(ci): stay on Node 10.6 for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "10"
+  - "10.6" # TODO fix snapshots on 10.7
   - "9"
   - "8"
 


### PR DESCRIPTION
10.7 causes some error snapshots to look differently