### PR TITLE
feat(assertion-block): supply assertion error message

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "10.6" # TODO fix snapshots on 10.7
+  - "10"
   - "9"
   - "8"
 

--- a/functional-tests/assertion-block/__snapshots__/assert-function-name.test.ts.snap
+++ b/functional-tests/assertion-block/__snapshots__/assert-function-name.test.ts.snap
@@ -5,20 +5,20 @@ exports[`does not rename non-conflicting bindings of the same name 1`] = `
 {
   let check;
 }
-check(1 === 1);"
+check(1 === 1, \\"(1 === 1) is not truthy\\");"
 `;
 
 exports[`generates import with specified name when autoImport is set 1`] = `
 "import check from \\"power-assert\\";
-check(1 === 1);"
+check(1 === 1, \\"(1 === 1) is not truthy\\");"
 `;
 
-exports[`generates specified assert function 1`] = `"check(1 === 1);"`;
+exports[`generates specified assert function 1`] = `"check(1 === 1, \\"(1 === 1) is not truthy\\");"`;
 
 exports[`renames conflicting bindings when autoImporting 1`] = `
 "import check from \\"power-assert\\";
 
 let _check;
 
-check(1 === 1);"
+check(1 === 1, \\"(1 === 1) is not truthy\\");"
 `;

--- a/functional-tests/assertion-post-processor-regular-errors/__snapshots__/jest-regular-errors.test.ts.snap
+++ b/functional-tests/assertion-post-processor-regular-errors/__snapshots__/jest-regular-errors.test.ts.snap
@@ -8,14 +8,14 @@ Array [
 ]
 `;
 
-exports[`does not require AssertionError in scope with autoImport enabled 1`] = `[Error: false == true]`;
+exports[`does not require AssertionError in scope with autoImport enabled 1`] = `[Error: (1 === 2) is not truthy]`;
 
 exports[`keeps the pretty error message from powerAssert 1`] = `
-[Error:   # test.js:1
+[Error: (1 === 2) is not truthy   # test.js:1
   
-  assert(1 === 2)
-           |     
-           false 
+  assert(1 === 2, "(1 === 2) is not truthy")
+           |                                
+           false                            
   
   [number] 2
   => 2
@@ -24,4 +24,4 @@ exports[`keeps the pretty error message from powerAssert 1`] = `
   ]
 `;
 
-exports[`throws plain Errors instead of AssertionErrors 1`] = `[Error: false == true]`;
+exports[`throws plain Errors instead of AssertionErrors 1`] = `[Error: (1 === 2) is not truthy]`;

--- a/functional-tests/power-assert/__snapshots__/power-assert.test.ts.snap
+++ b/functional-tests/power-assert/__snapshots__/power-assert.test.ts.snap
@@ -2,12 +2,12 @@
 
 exports[`leaves unrelated assert statements untouched 1`] = `"false == true"`;
 
-exports[`prints a nice error for an "expected"-labeled expression statement 1`] = `
-"  # test.js:1
+exports[`prints a nice error for an "expect"-labeled expression statement 1`] = `
+"(1 === 2) is not truthy   # test.js:1
   
-  assert(1 === 2)
-           |     
-           false 
+  assert(1 === 2, \\"(1 === 2) is not truthy\\")
+           |                                
+           false                            
   
   [number] 2
   => 2
@@ -17,11 +17,11 @@ exports[`prints a nice error for an "expected"-labeled expression statement 1`] 
 `;
 
 exports[`still works if babel-plugin-espower is used for other assertions in the file 1`] = `
-"  # test.js:2
+"(x > 0) is not truthy   # test.js:2
   
-  assert(x > 0)
-         | |   
-         0 false
+  assert(x > 0, \\"(x > 0) is not truthy\\")
+         | |                            
+         0 false                        
   "
 `;
 
@@ -36,12 +36,12 @@ exports[`still works if babel-plugin-espower is used for other assertions in the
 `;
 
 exports[`supports non-standard JSX syntax 1`] = `
-"  # test.js:1
+"(<div></div>.prop === 'expected') is not truthy   # test.js:1
   
-  assert(<div></div>.prop === 'expected')
-                     |    |              
-                     |    false          
-                     \\"div\\"               
+  assert(<div></div>.prop === 'expected', \\"(<div></div>.prop === 'expected') is not truthy\\")
+                     |    |                                                                 
+                     |    false                                                             
+                     \\"div\\"                                                                  
   
   --- [string] 'expected'
   +++ [string] <div></div>.prop
@@ -53,11 +53,11 @@ exports[`supports non-standard JSX syntax 1`] = `
 `;
 
 exports[`works when using autoImport 1`] = `
-"  # test.js:1
+"(1 === 2) is not truthy   # test.js:1
   
-  _assert(1 === 2)
-            |     
-            false 
+  _assert(1 === 2, \\"(1 === 2) is not truthy\\")
+            |                                
+            false                            
   
   [number] 2
   => 2

--- a/functional-tests/power-assert/power-assert.test.ts
+++ b/functional-tests/power-assert/power-assert.test.ts
@@ -1,10 +1,11 @@
 import { transform } from '@babel/core';
+import realAssert from 'assert';
 import assert from 'power-assert';
 
 import plugin from '@spockjs/babel-plugin-spock';
 import { Config, minimalConfig } from '@spockjs/config';
 
-test('prints a nice error for an "expected"-labeled expression statement', () => {
+test('prints a nice error for an "expect"-labeled expression statement', () => {
   const { code } = transform(`expect: 1 === 2;`, {
     plugins: [[plugin, { ...minimalConfig, powerAssert: true } as Config]],
     filename: 'test.js',
@@ -31,7 +32,7 @@ test('leaves unrelated assert statements untouched', () => {
   });
 
   expect(() =>
-    new Function('assert', code as string)(assert),
+    new Function('assert', code as string)(realAssert),
   ).toThrowErrorMatchingSnapshot();
 });
 

--- a/integration-tests/ava/no-preset/__snapshots__/ava.test.ts.snap
+++ b/integration-tests/ava/no-preset/__snapshots__/ava.test.ts.snap
@@ -21,7 +21,7 @@ exports[`produces very verbose output by default 1`] = `
     actual: false,
     code: 'ERR_ASSERTION',
     expected: true,
-    generatedMessage: true,
+    generatedMessage: false,
     operator: '==',
     powerAssertContext: {
       args: [
@@ -29,19 +29,19 @@ exports[`produces very verbose output by default 1`] = `
       ],
       source: {
         ast: Object { … },
-        content: '_assert(x === double(2))',
+        content: '_assert(x === double(2), \\"(x === double(2)) is not truthy\\")',
         filepath: 'ava.js',
         line: 12,
         tokens: Array [ … ],
         visitorKeys: Object { … },
       },
     },
-    message: \`  # ava.js:12␊
+    message: \`(x === double(2)) is not truthy   # ava.js:12␊
       ␊
-      _assert(x === double(2))␊
-              | |   |         ␊
-              | |   4         ␊
-              3 false         ␊
+      _assert(x === double(2), \\"(x === double(2)) is not truthy\\")␊
+              | |   |                                            ␊
+              | |   4                                            ␊
+              3 false                                            ␊
       ␊
       [number] double(2)␊
       => 4␊

--- a/integration-tests/ava/preset/__snapshots__/runner-ava.test.ts.snap
+++ b/integration-tests/ava/preset/__snapshots__/runner-ava.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`produces clean output with runner-ava preset 1`] = `
 "
     successful test
-    failing test 
+    failing test (x === double(2)) is not truthy
 
   1 test failed
 
@@ -14,6 +14,8 @@ exports[`produces clean output with runner-ava preset 1`] = `
    11:   when: x = 3;          
    12:   then: x === double(2);
    13: });                     
+
+  (x === double(2)) is not truthy
 
   Value is not truthy:
 

--- a/integration-tests/codemod/__snapshots__/codemod.test.ts.snap
+++ b/integration-tests/codemod/__snapshots__/codemod.test.ts.snap
@@ -2,8 +2,8 @@
 
 exports[`generates code that looks hand-written 1`] = `
 "import assert from \\"assert\\";
-assert(1 === 1);
-assert(2 === 2);
-assert(3 === 4);
+assert(1 === 1, \\"(1 === 1) is not truthy\\");
+assert(2 === 2, \\"(2 === 2) is not truthy\\");
+assert(3 === 4, \\"(3 === 4) is not truthy\\");
 "
 `;

--- a/integration-tests/codemod/codemod.test.ts
+++ b/integration-tests/codemod/codemod.test.ts
@@ -49,6 +49,6 @@ test('generates code that performs the assertion', () => {
 
   expect: status === 1;
   expect(stderr.toString()).toMatch(
-    /AssertionError \[ERR_ASSERTION\]: false == true/,
+    /AssertionError \[ERR_ASSERTION\]: \(3 === 4\) is not truthy/,
   );
 });

--- a/integration-tests/jasmine/__snapshots__/jasmine.test.ts.snap
+++ b/integration-tests/jasmine/__snapshots__/jasmine.test.ts.snap
@@ -7,12 +7,12 @@ exports[`produces correct output 1`] = `
 Failures:
 1) jasmine with spock failing test
   Message:
-    AssertionError [ERR_ASSERTION]:   # jasmine.js:11
+    AssertionError [ERR_ASSERTION]: (x === double(2)) is not truthy   # jasmine.js:11
       
-      _assert(x === double(2))
-              | |   |         
-              | |   4         
-              3 false         
+      _assert(x === double(2), \\"(x === double(2)) is not truthy\\")
+              | |   |                                            
+              | |   4                                            
+              3 false                                            
       
       [number] double(2)
       => 4

--- a/integration-tests/jest/no-preset/__snapshots__/jest.test.ts.snap
+++ b/integration-tests/jest/no-preset/__snapshots__/jest.test.ts.snap
@@ -9,5 +9,18 @@ exports[`produces slightly too verbose output by default 1`] = `
       true
     Received:
       false
+
+    Message:
+      (x === double(2)) is not truthy   # jest.js:10
+      
+      _assert(x === double(2), \\"(x === double(2)) is not truthy\\")
+              | |   |                                            
+              | |   4                                            
+              3 false                                            
+      
+      [number] double(2)
+      => 4
+      [number] x
+      => 3
 "
 `;

--- a/integration-tests/jest/preset/__snapshots__/runner-jest.test.ts.snap
+++ b/integration-tests/jest/preset/__snapshots__/runner-jest.test.ts.snap
@@ -3,12 +3,12 @@
 exports[`produces clean output with runner-jest preset 1`] = `
 "  ● failing test
 
-      # jest.js:10
+    (x === double(2)) is not truthy   # jest.js:10
       
-      _assert(x === double(2))
-              | |   |         
-              | |   4         
-              3 false         
+      _assert(x === double(2), \\"(x === double(2)) is not truthy\\")
+              | |   |                                            
+              | |   4                                            
+              3 false                                            
       
       [number] double(2)
       => 4

--- a/integration-tests/mocha/__snapshots__/mocha.test.ts.snap
+++ b/integration-tests/mocha/__snapshots__/mocha.test.ts.snap
@@ -1,12 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`produces correct output 1`] = `
-"  # mocha.js:10
+"(x === double(2)) is not truthy   # mocha.js:10
   
-  _assert(x === double(2))
-          | |   |         
-          | |   4         
-          3 false         
+  _assert(x === double(2), \\"(x === double(2)) is not truthy\\")
+          | |   |                                            
+          | |   4                                            
+          3 false                                            
   
   [number] double(2)
   => 4

--- a/integration-tests/tape/__snapshots__/tape.test.ts.snap
+++ b/integration-tests/tape/__snapshots__/tape.test.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`produces correct output 1`] = `"AssertionError [ERR_ASSERTION]: # tape.js:13 _assert(x === double(2)) | | | | | 4 3 false [number] double(2) => 4 [number] x => 3"`;
+exports[`produces correct output 1`] = `"AssertionError [ERR_ASSERTION]: (x === double(2)) is not truthy # tape.js:13 _assert(x === double(2), \\"(x === double(2)) is not truthy\\") | | | | | 4 3 false [number] double(2) => 4 [number] x => 3"`;

--- a/packages/assertion-block/package.json
+++ b/packages/assertion-block/package.json
@@ -20,6 +20,7 @@
     "url": "https://github.com/spockjs/spockjs/issues"
   },
   "dependencies": {
+    "@babel/generator": "7.0.0-beta.44",
     "@spockjs/auto-import-assert": "^0.6.0",
     "@spockjs/power-assert": "^0.6.0",
     "@spockjs/static-check": "^0.6.0"

--- a/packages/assertion-block/src/index.ts
+++ b/packages/assertion-block/src/index.ts
@@ -1,3 +1,4 @@
+import print from '@babel/generator';
 import { NodePath } from '@babel/traverse';
 import * as BabelTypes from '@babel/types';
 
@@ -48,7 +49,10 @@ export default (
         end: origExpr.loc.start,
       };
 
-      const newExpr = t.callExpression(assertIdentifier, [origExpr]);
+      const newExpr = t.callExpression(assertIdentifier, [
+        origExpr,
+        t.stringLiteral(`(${print(origExpr).code}) is not truthy`),
+      ]);
       newExpr.loc = origExpr.loc;
       statement.expression = newExpr;
 
@@ -64,7 +68,7 @@ export default (
         ({ path, patterns }, postProcess) => postProcess(path, patterns),
         {
           path: statementPath,
-          patterns: [`${assertIdentifier.name}(value)`],
+          patterns: [`${assertIdentifier.name}(value, [message])`],
         },
       );
 

--- a/packages/assertion-post-processor-ava-assert/src/index.ts
+++ b/packages/assertion-post-processor-ava-assert/src/index.ts
@@ -14,7 +14,7 @@ const processor: AssertionPostProcessor = (t, config) => path => {
   delete (tTruthy as any).optional;
 
   assertionExpression.callee = tTruthy;
-  return { path, patterns: ['t.truthy(value)'] };
+  return { path, patterns: ['t.truthy(value, [message])'] };
 };
 
 export default processor;

--- a/typings/babel.d.ts
+++ b/typings/babel.d.ts
@@ -17,6 +17,13 @@ declare module '@babel/template' {
   export default template;
 }
 
+declare module '@babel/generator' {
+  export * from 'babel-generator';
+
+  import generator from 'babel-generator';
+  export default generator;
+}
+
 declare module '@babel/helper-module-imports' {
   import { NodePath } from '@babel/traverse';
   import { Node } from '@babel/types';


### PR DESCRIPTION
This makes assertion errors more descriptive
in case power-assert is not used.
It also happens to resolve the problem of
different assertion error messages
in different Node versions.

BREAKING CHANGE:
Generated assertions may now contain a message
as a second parameter to the assert function.
AssertionPostProcessors will need to take this into account
both for returning a power-assert pattern
and for their own AST transformations.